### PR TITLE
SIGHUP via systemd reload

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -197,11 +197,19 @@ Example file:
     .*:Out R
         system:playback_2
 
+**Easy way to create a pattern file**
+
+Setup your JACK connections by GUI supported tools like ``QJackCtl`` or ``Carla`` first. Then use ``jack-matchmaker -c`` to get a *pattern file compatible* list of the current JACK environment. You can copy & paste the entries you want directly into your pattern file.
+
+**Reload pattern file**
+
 When you send a HUP signal to a running ``jack-matchmaker`` process, the file
 that was specified on the command line when the process was started is re-read
 and the resulting patterns replace *all* previously used patterns (including
 those listed as positional command line arguments!). If there should be an
 error reading the file, the pattern list will then be empty.
+
+On systemd you can use ``systemctl --user reload jack-matchmaker`` to reload the pattern file.
 
 
 JACK server connection
@@ -247,6 +255,12 @@ To stop it again:
 .. code-block:: shell-session
 
     $ systemctl --user stop jack-matchmaker
+
+Reload pattern file:
+
+.. code-block:: shell-session
+
+    $ systemctl --user reload jack-matchmaker
 
 
 Environment file

--- a/systemd/jack-matchmaker.service
+++ b/systemd/jack-matchmaker.service
@@ -3,6 +3,7 @@ Description=auto-connect JACK ports matching given patterns
 
 [Service]
 EnvironmentFile=/etc/conf.d/jack-matchmaker
+ExecReload=kill -HUP $MAINPID
 ExecStart=/bin/bash -c '/usr/bin/jack-matchmaker $${PATTERN_FILE+-p "$PATTERN_FILE"} $${EXACT_MATCHING:+-e} $${CLIENT_NAME+-N "$CLIENT_NAME"} $${CONNECT_INTERVAL+-I $CONNECT_INTERVAL} $${MAX_ATTEMPTS+-m $MAX_ATTEMPTS} $${VERBOSITY+-v $VERBOSITY} $$PATTERNS'
 
 [Install]


### PR DESCRIPTION
As stated in the readme:
> When you send a HUP signal to a running jack-matchmaker process, the file that was specified on the command line when the process was started is re-read and the resulting patterns replace all previously used patterns (including those listed as positional command line arguments!).

This will allow `systemctl --user reload jack-matchmaker` to send the SIGHUP signal and reload the pattern file.

