### PR TITLE
Add monitoring of input ports

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,6 +113,14 @@ port pattern:
     $ jack-matchmaker \
         'system:midi_capture_(?P<num>\d+)$' 'mydaw:midi_in_track_{num}'
 
+Automatically connect all ports going to the system output to an FFmpeg
+recording instance as well:
+
+.. code-block:: shell-session
+
+    $ jack-matchmaker \
+        'system:playback_(?P<num>\d+)$' 'ffmpeg:input_{num}'
+
 
 Regular expression and exact matching
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -40,8 +40,13 @@ one of the port pattern pairs given on the command line at startup.
 The port name patterns are specified as pairs of positional arguments or read
 from a file (see below) and *by default* are always interpreted as `Python
 regular expressions`_, where the first pattern of a pair is matched against
-output (readable) ports and the second pattern of a pair is matched against
-input (writeable) ports. As many pattern pairs as needed can be given.
+both output (readable) ports and input (writeable) ports, and the second
+pattern of a pair is matched only against input ports. As many pattern pairs as
+needed can be given.
+
+If the first pattern matches an input port, all output
+ports connected to that input port will be connected to the input ports
+matching the second pattern.
 
 Patterns are matched against:
 


### PR DESCRIPTION
This PR adds the ability to "monitor" input ports, similar to the way `jack_capture` makes its connections.
Specifically, if an input port is matched as the first pattern, then each of the output ports connected to that input port will be connected to the input port matched in the second pattern.

The easiest demonstration is likely visual:
![image](https://user-images.githubusercontent.com/1972633/143212236-127ab6b6-e98b-4fe1-a468-8ba1b76e061f.png)
First, `jack-matchmaker 'system:playback_1' 'simple:input'` was started. Then, the `simple` device was registered.
Upon registration, `jack-matchmaker` connected its  `input` port to the same input ports as `system:playback_1`.

I have code stashed to add a callback for new connections, so that they get captured also; however, this causes a new refresh to happen each time the connections are updated by `jack-matchmaker` as well. Additionally, monitoring the removal of connections to match would be a much more significant change.